### PR TITLE
Run Inklecate through mono on Linux

### DIFF
--- a/executableHandler.js
+++ b/executableHandler.js
@@ -16,13 +16,17 @@ module.exports = (args) => {
     verbose,
   } = args;
 
-  const proc = spawn(getInklecatePath(), [
+  const opts = [
     countAllVisits ? ArgsEnum.CountAllVisits : null,
     verbose ? ArgsEnum.Verbose : null,
     ArgsEnum.OutputFile,
     outputFilepath,
     inputFilepath,
-  ].filter(Boolean));
+  ].filter(Boolean);
+
+  const proc = (process.platform === 'linux') ?
+    spawn("mono", [getInklecatePath()].concat(opts)) :
+    spawn(getInklecatePath(), opts);
 
   const compilerOutput = [];
 


### PR DESCRIPTION
Hey I couldn't get this working on Linux since it tries directly executing the .exe (and the other executable is for MacOS?). Since the compiler is built in C#, it can be run on Linux just by using `mono`, so this was an easy fix I did to get it working on my system. I'm not sure if there's a more "correct" solution to do this in a more "nodey" way, or if perhaps all that otherwise needs to be changed is documentation specifying that the `mono` executable needs to be installed on your system on Linux, but this was just how I initially thought to fix it.